### PR TITLE
Some fixes

### DIFF
--- a/iocs/mythenIOC/iocBoot/iocMythen/st.cmd
+++ b/iocs/mythenIOC/iocBoot/iocMythen/st.cmd
@@ -15,13 +15,11 @@ drvAsynIPPortConfigure("IP_M1K", "192.168.0.90:1030 UDP", 0, 0, 1)
 #drvAsynIPPortConfigure("IP_M1K", "192.168.0.90:1031", 0, 0, 1)
 #drvAsynIPPortConfigure("IP_M1K", "164.54.109.66:1031", 0, 0, 0)
 
-
 #asynOctetSetInputEos("IP_M1K",0,"\r\n")
 asynOctetSetOutputEos("IP_M1K",0,"\r")
 
 asynSetTraceIOMask("IP_M1K",0,6)
 asynSetTraceMask("IP_M1K",0,3)
-
 
 epicsEnvSet("PREFIX","dp_mythen1K:")
 epicsEnvSet("PORT",   "SD1")
@@ -43,18 +41,14 @@ mythenConfig("SD1", "IP_M1K", -1,-1)
 
 asynSetTraceMask("IP_M1K",0,1)
 
-dbLoadRecords("$(ADCORE)/db/ADBase.template",   "P=$(PREFIX),R=cam1:,PORT=$(PORT),ADDR=0,TIMEOUT=1")
-dbLoadRecords("$(ADCORE)/db/NDFile.template",   "P=$(PREFIX),R=cam1:,PORT=$(PORT),ADDR=0,TIMEOUT=1")
-dbLoadRecords("$(ADMYTHEN)/mythenApp/Db/mythen.template",        "P=$(PREFIX),R=cam1:,PORT=$(PORT),ADDR=0,TIMEOUT=1")
+dbLoadRecords("$(ADMYTHEN)/mythenApp/Db/mythen.template", "P=$(PREFIX),R=cam1:,PORT=$(PORT),ADDR=0,TIMEOUT=1")
 
 # Create a standard arrays plugin
 NDStdArraysConfigure("Image1", 3, 0, "$(PORT)", 0, 0)
-# This is now included in NDStdArrays
-#dbLoadRecords("$(ADCORE)/db/NDPluginBase.template","P=$(PREFIX),R=image1:,PORT=Image1,ADDR=0,TIMEOUT=1,NDARRAY_PORT=$(PORT),NDARRAY_ADDR=0")
 dbLoadRecords("$(ADCORE)/db/NDStdArrays.template", "P=$(PREFIX),R=image1:,PORT=Image1,ADDR=0,TIMEOUT=1,NDARRAY_PORT=$(PORT),NDARRAY_ADDR=0,TYPE=Float64,FTVL=DOUBLE,NELEMENTS=$(NCHANS)")
 
 # Load all other plugins using commonPlugins.cmd
-< $(ADCORE)/iocBoot/commonPlugins.cmd
+< $(ADEXAMPLE)/iocBoot/commonPlugins.cmd
 
 # Load asynRecord records on Mythen communication
 dbLoadRecords("$(ASYN)/db/asynRecord.db", "P=$(PREFIX),R=asyn_1,PORT=IP_M1K,ADDR=0,OMAX=256,IMAX=256")

--- a/iocs/mythenIOC/mythenApp/src/Makefile
+++ b/iocs/mythenIOC/mythenApp/src/Makefile
@@ -16,7 +16,7 @@ PROD_SRCS += $(PROD_NAME)_registerRecordDeviceDriver.cpp $(PROD_NAME)Main.cpp
 # Add locally compiled object code
 PROD_LIBS += mythen
 
-include $(ADCORE)/ADApp/commonDriverMakefile
+include $(ADEXAMPLE)/exampleApp/commonDriverMakefile
 $(PROD_NAME)_DBD += drvAsynIPPort.dbd
 
 #=============================

--- a/mythenApp/Db/mythen.template
+++ b/mythenApp/Db/mythen.template
@@ -2,7 +2,6 @@
 # template for Dectris Mythen Driver
 
 include "ADBase.template"
-include "NDFile.template"
 
 #----------------------------------
 # Detector Setting

--- a/mythenApp/src/Makefile
+++ b/mythenApp/src/Makefile
@@ -4,20 +4,13 @@ include $(TOP)/configure/CONFIG
 #  ADD MACRO DEFINITIONS AFTER THIS LINE
 #=============================
 
-
 LIBRARY_IOC += mythen
 LIB_SRCS += mythen.cpp
-
 
 # <name>.dbd will be created from <name>Include.dbd
 DBD += mythenSupport.dbd
 
-
-#include $(AREA_DETECTOR)/ADApp/commonDriverMakefile
-include $(ADCORE)/ADApp/commonDriverMakefile
-
-#PROD_LIBS += NDFileMagick
-#PROD_LIBS += GraphicsMagick++ GraphicsMagickWand GraphicsMagick
+include $(ADCORE)/ADApp/commonLibraryMakefile
 
 #=============================
 

--- a/mythenApp/src/mythen.cpp
+++ b/mythenApp/src/mythen.cpp
@@ -29,6 +29,7 @@
 
 #include <epicsTime.h>
 #include <epicsThread.h>
+#include <epicsEndian.h>
 #include <epicsEvent.h>
 #include <epicsMutex.h>
 #include <epicsString.h>
@@ -153,67 +154,112 @@ public:
     char firmwareVersion_[7];
     char outString_[MAX_COMMAND_LEN];
     char inString_[MAX_COMMAND_LEN];
+    bool isBigEndian_;
     asynStatus sendCommand();
     asynStatus writeReadMeter();
-
+    epicsInt32 stringToInt32(char *str);
+    long long stringToInt64(char *str);
+    epicsFloat32 stringToFloat32(char *str);
+    void swap4(char* value);
+    void swap8(char* value);
 };
 
 #define NUM_SD_PARAMS (&LAST_SD_PARAM - &FIRST_SD_PARAM + 1)
 
+void mythen::swap4(char *value)
+{
+    char temp;
+    temp = value[0];
+    value[0] = value[3];
+    value[3] = temp;
+    temp = value[1];
+    value[1] = value[2];
+    value[2] = temp;
+}
+
+void mythen::swap8(char *value)
+{
+    char temp;
+    temp = value[0];
+    value[0] = value[7];
+    value[7] = temp;
+    temp = value[1];
+    value[1] = value[6];
+    value[6] = temp;
+    temp = value[2];
+    value[2] = value[5];
+    value[5] = temp;
+    temp = value[3];
+    value[3] = value[4];
+    value[4] = temp;
+}
+
+epicsInt32 mythen::stringToInt32(char *str)
+{
+    epicsInt32 value = *reinterpret_cast<epicsInt32*>(str);
+    if (isBigEndian_) swap4((char *)&value);
+    return value;
+}
+
+long long mythen::stringToInt64(char *str)
+{
+    long long value = *reinterpret_cast<long long*>(str);
+    if (isBigEndian_) swap8((char *)&value);
+    return value;
+}
+
+epicsFloat32 mythen::stringToFloat32(char *str)
+{
+    epicsFloat32 value = *reinterpret_cast<epicsFloat32*>(str);
+    if (isBigEndian_) swap4((char *)&value);
+    return value;
+}
+
 /** Sends a command to the detector and reads the response.**/
 asynStatus mythen::sendCommand()
 {
-  // int prevAcquiring;
   asynStatus status;
   const char *functionName="sendCommand";
   int aux;
 
-  // prevAcquiring = acquiring_;
-  // if (prevAcquiring) setAcquire(0);
   status = writeReadMeter();
-  aux=*((int*)this->inString_);
+  aux = stringToInt32(this->inString_);
   //check for errors
   if (aux < 0){
       asynPrint(pasynUserSelf, ASYN_TRACE_ERROR,
           "%s:%s: error, expected 0, received %d\n",
           driverName, functionName, aux);
   }
-  // if (prevAcquiring) setAcquire(1);
   return status;
 }
 
 /** Send a string to the detector and reads the response.**/
 asynStatus mythen::writeReadMeter()
 {
-	size_t nread;
-	size_t nwrite;
-	asynStatus status;
-	int eomReason;
-  char temp[7];
-	const char *functionName="writeReadMeter";
+    size_t nread;
+    size_t nwrite;
+    asynStatus status;
+    int eomReason;
+    const char *functionName="writeReadMeter";
 
-	if(strcmp(outString_,"-get tau")==0)
-	{
-	 status = pasynOctetSyncIO->writeRead(pasynUserMeter_, outString_, strlen(outString_),
-		 inString_, sizeof(epicsFloat32), M1K_TIMEOUT, &nwrite, &nread, &eomReason);
-	}
-	else
-	  {
-	    if (strcmp(outString_,"-get version")==0)
-	    {
-	      status = pasynOctetSyncIO->writeRead(pasynUserMeter_, outString_, strlen(outString_),
-		            firmwareVersion_, sizeof(firmwareVersion_), M1K_TIMEOUT, &nwrite, &nread, &eomReason);
-	    }
-	    else
-	    {
-	      status = pasynOctetSyncIO->writeRead(pasynUserMeter_, outString_, strlen(outString_),
-		        inString_, sizeof(int), M1K_TIMEOUT, &nwrite, &nread, &eomReason);
-		  }
-		}
-	if(status != asynSuccess)
-	      asynPrint(pasynUserSelf, ASYN_TRACE_ERROR,
-	          "%s:%s: error!\n",driverName, functionName);
-	return status;
+    if(strcmp(outString_,"-get tau")==0) {
+     status = pasynOctetSyncIO->writeRead(pasynUserMeter_, outString_, strlen(outString_),
+         inString_, sizeof(epicsFloat32), M1K_TIMEOUT, &nwrite, &nread, &eomReason);
+    }
+    else {
+        if (strcmp(outString_,"-get version")==0) {
+          status = pasynOctetSyncIO->writeRead(pasynUserMeter_, outString_, strlen(outString_),
+                    firmwareVersion_, sizeof(firmwareVersion_), M1K_TIMEOUT, &nwrite, &nread, &eomReason);
+        }
+        else {
+          status = pasynOctetSyncIO->writeRead(pasynUserMeter_, outString_, strlen(outString_),
+                inString_, sizeof(int), M1K_TIMEOUT, &nwrite, &nread, &eomReason);
+        }
+    }
+    if(status != asynSuccess)
+          asynPrint(pasynUserSelf, ASYN_TRACE_ERROR,
+              "%s:%s: error!\n",driverName, functionName);
+    return status;
 }
 
 /** Starts and stops the acquisition. **/
@@ -231,22 +277,20 @@ asynStatus mythen::setAcquire(epicsInt32 value)
       //            status = pasynOctetSyncIO->setInputEos(pasynUserMeter_, "", 0);
       //            if (status) break;
       status = pasynOctetSyncIO->writeRead(pasynUserMeter_, "-stop", strlen(outString_),
-					   inString_, sizeof(epicsInt32), M1K_TIMEOUT, &nwrite, &nread, &eomReason);
-			setIntegerParam(ADStatus, getStatus());
-	    //            if (status == asynSuccess || status == asynTimeout) break;
-	    //        }
+                       inString_, sizeof(epicsInt32), M1K_TIMEOUT, &nwrite, &nread, &eomReason);
+            setIntegerParam(ADStatus, getStatus());
+        //            if (status == asynSuccess || status == asynTimeout) break;
+        //        }
       acquiring_ = 0;
     } else {
-    	if(!(acquiring_))
-    	{
-    	    	  
-	      strcpy(outString_,"-start");
-	      this->sendCommand();
-	      // Notify the read thread that acquisition has started
-      	      epicsEventSignal(startEventId_);
-	      
-	      acquiring_ = 1;
-    	}
+        if(!(acquiring_)) {                 
+          strcpy(outString_,"-start");
+          this->sendCommand();
+          // Notify the read thread that acquisition has started
+                epicsEventSignal(startEventId_);
+          
+          acquiring_ = 1;
+        }
     }
     if (status) {
         acquiring_ = 0;
@@ -286,22 +330,19 @@ asynStatus mythen::setTrigger(epicsInt32 value)
 {
     asynStatus status = asynSuccess;;
 
-    if (value == 0)
-      {
-	// Clearing trigen clears conttrig also
-	epicsSnprintf(outString_, sizeof(outString_), "-trigen 0");
-	status = sendCommand();
-      }
-    else if (value == 1)
-      {
-	epicsSnprintf(outString_, sizeof(outString_), "-trigen 1");
-	status = sendCommand();
-      }
-    else if (value == 2)
-      {
-       	epicsSnprintf(outString_, sizeof(outString_), "-conttrigen 1");
-	status = sendCommand();
-      }
+    if (value == 0) {
+      // Clearing trigen clears conttrig also
+      epicsSnprintf(outString_, sizeof(outString_), "-trigen 0");
+      status = sendCommand();
+    }
+    else if (value == 1) {
+      epicsSnprintf(outString_, sizeof(outString_), "-trigen 1");
+      status = sendCommand();
+    }
+    else if (value == 2) {
+      epicsSnprintf(outString_, sizeof(outString_), "-conttrigen 1");
+      status = sendCommand();
+    }
 
     return status;
 }
@@ -311,77 +352,69 @@ asynStatus mythen::setTrigger(epicsInt32 value)
 asynStatus mythen::setTau(epicsFloat64 value)
 {
     asynStatus status;
-    if(value == -1 || value > 0)
-    {
-		epicsSnprintf(outString_, sizeof(outString_), "-tau %f", value);
-		status = sendCommand();
+    if(value == -1 || value > 0) {
+        epicsSnprintf(outString_, sizeof(outString_), "-tau %f", value);
+        status = sendCommand();
     }
-    else
-    {
-		setDoubleParam(SDTau,0);
-		callParamCallbacks();
+    else {
+        setDoubleParam(SDTau,0);
+        callParamCallbacks();
 
         asynPrint(pasynUserSelf, ASYN_TRACE_ERROR,
             "error check if tau -1 or >0 (outString = %s)",outString_);
         return asynError;
     }
-	return status;
+    return status;
 }
 
 
 /** Sets the energy threshold for the module **/
 asynStatus mythen::setKthresh(epicsFloat64 value)
 {
-	epicsInt32 i;
+    epicsInt32 i;
     asynStatus status = asynSuccess;
-    for(i=0;i<this->nmodules;i++)
-    {
-		epicsSnprintf(outString_, sizeof(outString_), "-module %d",i);
-		status = sendCommand();
-		epicsSnprintf(outString_, sizeof(outString_), "-kthresh %f", value);
-		status = sendCommand();
+    for(i=0;i<this->nmodules;i++) {
+        epicsSnprintf(outString_, sizeof(outString_), "-module %d",i);
+        status = sendCommand();
+        epicsSnprintf(outString_, sizeof(outString_), "-kthresh %f", value);
+        status = sendCommand();
     }
-    if(status == asynSuccess)
-    {
-		setDoubleParam(SDThreshold,value);
-		callParamCallbacks();
+    if(status == asynSuccess) {
+        setDoubleParam(SDThreshold,value);
+        callParamCallbacks();
     }
-    else
-    {
-		setDoubleParam(SDThreshold,0);
-		callParamCallbacks();
+    else {
+        setDoubleParam(SDThreshold,0);
+        callParamCallbacks();
 
         asynPrint(pasynUserSelf, ASYN_TRACE_ERROR,
             "error check if value > 0 (outString = %s)",outString_);
         return asynError;
     }
-	return status;
+    return status;
 }
 
 
 /** Sets the energy threshold for the module **/
 asynStatus mythen::setEnergy(epicsFloat64 value)
 {
-	
-	epicsInt32 i;
+    
+    epicsInt32 i;
   asynStatus status = asynSuccess;
-  if ((int)firmwareVersion_[1]%48 >=3)
-  {
-    for(i=0;i<this->nmodules;i++)
-    {
-		epicsSnprintf(outString_, sizeof(outString_), "-module %d",i);
-		status = sendCommand();
-		epicsSnprintf(outString_, sizeof(outString_), "-energy %f", value);
-		status = sendCommand();
+  if ((int)firmwareVersion_[1]%48 >=3) {
+    for(i=0;i<this->nmodules;i++) {
+        epicsSnprintf(outString_, sizeof(outString_), "-module %d",i);
+        status = sendCommand();
+        epicsSnprintf(outString_, sizeof(outString_), "-energy %f", value);
+        status = sendCommand();
     }
-    if(status != asynSuccess)
-    {
+    if(status != asynSuccess) {
         asynPrint(pasynUserSelf, ASYN_TRACE_ERROR,
             "error check if value > 0 (outString = %s)",outString_);
         return asynError;
     }
   }
-	return status;
+  return status;
 }
 
 /** Sets the exposure time of one frame. (units of 100ns) **/
@@ -404,8 +437,8 @@ asynStatus mythen::setDelayAfterTrigger(epicsFloat64 value)
     return status;
 }
 
-/** Enables or disables the flatfield correction. After initialisation the
-flatfield correction is enabled. **/
+/** Enables or disables the flatfield correction. 
+    After initialisation the flatfield correction is enabled. **/
 asynStatus mythen::setFCorrection(epicsInt32 value)
 {
     asynStatus status;
@@ -426,8 +459,8 @@ asynStatus mythen::setBadChanIntrpl(epicsInt32 value)
 }
 
 
-/** Enables or disables the rate correction. After initialisation the
-rate correction is disabled. **/
+/** Enables or disables the rate correction. 
+    After initialisation the rate correction is disabled. **/
 asynStatus mythen::setRCorrection(epicsInt32 value)
 {
     asynStatus status;
@@ -437,8 +470,8 @@ asynStatus mythen::setRCorrection(epicsInt32 value)
     return status;
 }
 
-/** Enables or disables the gates. After initialisation the
-gates are disabled. **/
+/** Enables or disables the gates. 
+    After initialisation the gates are disabled. **/
 asynStatus mythen::setUseGates(epicsInt32 value)
 {
     asynStatus status;
@@ -461,9 +494,7 @@ asynStatus mythen::setNumGates(epicsInt32 value)
 /** Get Firmware Version **/
 asynStatus mythen::getFirmware()
 {
-    asynStatus status;
-    //char 
-    
+    asynStatus status=asynSuccess;
     
     epicsSnprintf(outString_, sizeof(outString_), "-get version");
     writeReadMeter();
@@ -480,7 +511,7 @@ epicsInt32 mythen::getStatus()
 
     strcpy(outString_, "-get status");
     writeReadMeter();
-    aux=*((int*)this->inString_);
+    aux = stringToInt32(this->inString_);
     int m_status =  aux & 1;          // Acquire running status (non-zero)
     int t_status = aux & (1<<3);      // Waiting for trigger (non-zero)        
     int d_status = aux & (1<<16);     // No Data Available when not zero
@@ -489,22 +520,19 @@ epicsInt32 mythen::getStatus()
     
     //printf("Mythen Status - M:%d\tT:%d\tD:%d\n",m_status,t_status, d_status);
     
-    if (m_status || !d_status )
-    { 
-      
+    if (m_status || !d_status ) { 
       detStatus = ADStatusAcquire;
       
       triggerWaitCnt=0;
       //Waits for Trigger for increaseing amount of time for a total of almost 1 minute
-      while ((t_status ) && (triggerWaitCnt<MAX_TRIGGER_TIMEOUT_COUNT))
-      {
+      while ((t_status ) && (triggerWaitCnt<MAX_TRIGGER_TIMEOUT_COUNT)) {
         triggerWait = 0.0001*pow(10.0,((double)(triggerWaitCnt/10)+1));
         //Wait
         epicsThreadSleep(triggerWait);
         //Check again
         strcpy(outString_, "-get status");
         writeReadMeter();
-        aux=*((int*)this->inString_);
+        aux = stringToInt32(this->inString_);
         t_status = aux & (1<<3);       
         d_status = aux & (1<<16);     
         triggerWaitCnt++;
@@ -538,24 +566,23 @@ asynStatus mythen::setBitDepth(epicsInt32 value)
 {
     asynStatus status;
     epicsInt32 nbits;
-    switch (value)
-      {
+    switch (value) {
       case 0: 
-	nbits = 24;
-	break;
+        nbits = 24;
+        break;
       case 1: 
-	nbits = 16;
-	break;
+        nbits = 16;
+        break;
       case 2:
-      	nbits = 8;
-	break;
+        nbits = 8;
+        break;
       case 3:
-	nbits = 4;
-	break;
+        nbits = 4;
+        break;
       default:
-	nbits = 24;
-	break;
-      }
+        nbits = 24;
+        break;
+    }
 
     epicsSnprintf(outString_, sizeof(outString_), "-nbits %d", nbits);
     status = sendCommand();
@@ -572,65 +599,56 @@ asynStatus mythen::loadSettings(epicsInt32 value)
     asynStatus status=asynSuccess;
     epicsInt32 i=0;
 
-    for(i=0;i<this->nmodules;i++)
-    {
-		epicsSnprintf(outString_, sizeof(outString_), "-module %d",i);
-		status = sendCommand();
+    for(i=0;i<this->nmodules;i++) {
+        epicsSnprintf(outString_, sizeof(outString_), "-module %d",i);
+        status = sendCommand();
 
-		switch(value){
-			//Cu
-			case 0:
-			  if ((int)firmwareVersion_[1]%48 >=3)
-          {
-				    epicsSnprintf(outString_, sizeof(outString_), "-settings Cu");
-				  }
-				else
-				  {
-				    epicsSnprintf(outString_, sizeof(outString_), "-settings StdCu");
-				  }
-				break;
+        switch(value){
+            //Cu
+            case 0:
+                if ((int)firmwareVersion_[1]%48 >=3) {
+                    epicsSnprintf(outString_, sizeof(outString_), "-settings Cu");
+                }
+                else {
+                    epicsSnprintf(outString_, sizeof(outString_), "-settings StdCu");
+                }
+                break;
 
-			//Mo
-			case 1:
-				
-				if ((int)firmwareVersion_[1]%48 >=3)
-          {
-				    epicsSnprintf(outString_, sizeof(outString_), "-settings Mo");
-				  }
-				else
-				  {
-				    epicsSnprintf(outString_, sizeof(outString_), "-settings StdMo");
-				  }
-				break;
+            //Mo
+            case 1:  
+                if ((int)firmwareVersion_[1]%48 >=3) {
+                    epicsSnprintf(outString_, sizeof(outString_), "-settings Mo");
+                  }
+                else {
+                    epicsSnprintf(outString_, sizeof(outString_), "-settings StdMo");
+                  }
+                break;
 
-			//Ag
-			//Not supported on firmware verions less than 3
-			case 2:
-				epicsSnprintf(outString_, sizeof(outString_), "-settings Ag");
-				break;
-				
-			// Cr
-      case 3:
-				
-				if ((int)firmwareVersion_[1]%48 >=3)
-          {
-				    epicsSnprintf(outString_, sizeof(outString_), "-settings Cr");
-				  }
-				else
-				  {
-				    epicsSnprintf(outString_, sizeof(outString_), "-settings HgCr");
-				  }
-				break;
-				
-			default:
-				epicsSnprintf(outString_, sizeof(outString_), "-reset");
-				break;
-		}
-		status = sendCommand();
+            //Ag
+            //Not supported on firmware verions less than 3
+            case 2:
+                epicsSnprintf(outString_, sizeof(outString_), "-settings Ag");
+                break;
+                
+            // Cr
+            case 3:                
+                if ((int)firmwareVersion_[1]%48 >=3) {
+                    epicsSnprintf(outString_, sizeof(outString_), "-settings Cr");
+                }
+                else {
+                    epicsSnprintf(outString_, sizeof(outString_), "-settings HgCr");
+                }
+                break;
+                
+            default:
+                epicsSnprintf(outString_, sizeof(outString_), "-reset");
+                break;
+        }
+        status = sendCommand();
     }
     setIntegerParam(SDSetting,value);
 
-	callParamCallbacks();
+    callParamCallbacks();
 
     return status;
 }
@@ -642,18 +660,17 @@ asynStatus mythen::setReset()
     asynStatus status=asynSuccess;
     epicsInt32 i=0;
 
-	setIntegerParam(SDReset,1);
-    for(i=0;i<this->nmodules;i++)
-    {
-		epicsSnprintf(outString_, sizeof(outString_), "-module %d",i);
-		status = sendCommand();
+    setIntegerParam(SDReset,1);
+    for(i=0;i<this->nmodules;i++) {
+        epicsSnprintf(outString_, sizeof(outString_), "-module %d",i);
+        status = sendCommand();
 
-		strcpy(outString_, "-reset");
-		status = sendCommand();
+        strcpy(outString_, "-reset");
+        status = sendCommand();
     }
-	setIntegerParam(SDReset,0);
-	callParamCallbacks();
-	return status;
+    setIntegerParam(SDReset,0);
+    callParamCallbacks();
+    return status;
 }
 
 
@@ -662,53 +679,47 @@ asynStatus mythen::getSettings()
 {
     int aux;
     epicsFloat32 faux;
+    long long laux;
     epicsFloat64 DetTime;
 
-    int prevAcquiring;
     static const char *functionName = "getSettings";
 
-    if (acquiring_)
-      {
-	      strcpy(outString_,"Called during Acquire");
-	      inString_[0] = NULL;
-	      goto error;
-      }
-    //    prevAcquiring = acquiring_;
-    //    if (prevAcquiring) setAcquire(0);
+    if (acquiring_) {
+        strcpy(outString_,"Called during Acquire");
+        inString_[0] = 0;
+        goto error;
+    }
 
     strcpy(outString_, "-get flatfieldcorrection");
     writeReadMeter();
-    aux=*((int*)this->inString_);
+    aux = stringToInt32(this->inString_);
     if (aux!=0 && aux!=1) goto error;
     setIntegerParam(SDUseFlatField, aux);
 
 
     strcpy(outString_, "-get badchannelinterpolation");
     writeReadMeter();
-    aux=*((int*)this->inString_);
+    aux = stringToInt32(this->inString_);
     if (aux!=0 && aux!=1) goto error;
     setIntegerParam(SDUseBadChanIntrpl, aux);
 
     strcpy(outString_, "-get ratecorrection");
     writeReadMeter();
-    aux=*((int*)this->inString_);
+    aux = stringToInt32(this->inString_);
     if (aux!=0 && aux!=1) goto error;
     setIntegerParam(SDUseCountRate, aux);
 
     strcpy(outString_, "-get nbits");
     writeReadMeter();
-    aux=*((int*)this->inString_);
+    aux = stringToInt32(this->inString_);
     if (aux < 0) goto error;
-    else 
-      {
-        nbits_ = aux;
-	chanperline_ = 32/aux; 
-	setIntegerParam(SDBitDepth, aux);
-      }
+    nbits_ = aux;
+    chanperline_ = 32/aux; 
+    setIntegerParam(SDBitDepth, aux);
 
     strcpy(outString_, "-get time");
     writeReadMeter();
-    aux=*((long*)this->inString_);
+    aux = stringToInt32(this->inString_);
     if (aux >= 0) DetTime = (aux * (1E-7));
     else goto error;
     setDoubleParam(ADAcquireTime,DetTime);
@@ -717,12 +728,12 @@ asynStatus mythen::getSettings()
 
     strcpy(outString_, "-get frames");
     writeReadMeter();
-    aux=*((int*)this->inString_);
+    aux = stringToInt32(this->inString_);
     if (aux >= 0) setIntegerParam(SDNumFrames, aux);
 
     strcpy(outString_, "-get tau");
     writeReadMeter();
-    faux=*((epicsFloat32*)this->inString_);
+    faux = stringToFloat32(this->inString_);
     if (faux == -1 || faux > 0) setDoubleParam(SDTau,faux);
     else goto error;
 
@@ -730,26 +741,23 @@ asynStatus mythen::getSettings()
 
     strcpy(outString_, "-get kthresh");
     writeReadMeter();
-    faux=*((epicsFloat32*)this->inString_);
+    faux = stringToFloat32(this->inString_);
     if (faux < 0) goto error;
     else setDoubleParam(SDThreshold,faux);
-
-    
       
       
     //Firmware greater than 3 commands  
-    if ((int)firmwareVersion_[1]%48 >=3)
-    {
+    if ((int)firmwareVersion_[1]%48 >=3) {
       strcpy(outString_, "-get energy");
       writeReadMeter();
-      faux=*((epicsFloat32*)this->inString_);
+      faux = stringToFloat32(this->inString_);
       if (faux < 0) goto error;
       else setDoubleParam(SDEnergy,faux);
       
       strcpy(outString_, "-get delafter");
       writeReadMeter();
-      aux=*((long*)this->inString_);
-      if (aux >= 0) DetTime = (aux * (1E-7));
+      laux = stringToInt64(this->inString_);
+      if (laux >= 0) DetTime = (laux * (1E-7));
       else goto error;
       setDoubleParam(SDDelayTime,DetTime);
       
@@ -757,21 +765,20 @@ asynStatus mythen::getSettings()
       /* Get trigger modes */
       strcpy(outString_, "-get conttrig");
       writeReadMeter();
-      aux=*((int*)this->inString_);
+      aux = stringToInt32(this->inString_);
       if (aux < 0) goto error;
       if (aux == 1) 
-	      setIntegerParam(SDTrigger, 2);
-      else 
-        {
-        	strcpy(outString_, "-get trig");
-	        writeReadMeter();
-         	aux=*((int*)this->inString_);
-	        if (aux < 0) goto error;
-	        if (aux == 1)
-	          setIntegerParam(SDTrigger, 1);
-	        else
-	          setIntegerParam(SDTrigger, 0);
-        }
+          setIntegerParam(SDTrigger, 2);
+      else {
+        strcpy(outString_, "-get trig");
+        writeReadMeter();
+        aux = stringToInt32(this->inString_);
+        if (aux < 0) goto error;
+        if (aux == 1)
+          setIntegerParam(SDTrigger, 1);
+        else
+          setIntegerParam(SDTrigger, 0);
+      }
     }
 
     callParamCallbacks();
@@ -787,10 +794,10 @@ asynStatus mythen::getSettings()
 }
 
 
-static void c_shutdown(void* arg) {
-    mythen *p = (mythen*)arg;
-    p->shutdown(); 
-}
+//static void c_shutdown(void* arg) {
+//    mythen *p = (mythen*)arg;
+//    p->shutdown(); 
+//}
 
 
 void acquisitionTaskC(void *drvPvt)
@@ -820,8 +827,8 @@ void mythen::pollTask()
 
         /* Update detector status */
         this->lock(); 
-	//        int detStatus = pDetector->getDetectorStatus();
-	//        setIntegerParam(ADStatus, detStatus);
+        // int detStatus = pDetector->getDetectorStatus();
+        // setIntegerParam(ADStatus, detStatus);
         callParamCallbacks(); 
         this->unlock(); 
     }
@@ -837,24 +844,17 @@ void mythen::acquisitionTask()
     epicsInt32 detArray[this->nmodules*1280];
     double acquireTime;
     asynStatus status = asynSuccess;
-    int dataOK, retry;
-    double triggerWait = 0.001;
-    int triggerWaitCnt = 0;
+    int dataOK;
 
     static const char *functionName = "acquisitionTask";
     this->lock(); 
 
-    while (1) 
-    {
+    while (1) {
         /* Is acquisition active? */
         getIntegerParam(ADAcquire, &acquire);
         
         /* If we are not acquiring then wait for a semaphore that is given when acquisition is started */
-        if (!acquire || !acquiring_) 
-        {
-            
-            triggerWaitCnt = 0;
-            
+        if (!acquire || !acquiring_)  {
             setIntegerParam(ADStatus, ADStatusIdle);
             callParamCallbacks();
             /* Release the lock while we wait for an event that says acquire has started, then lock again */
@@ -864,25 +864,23 @@ void mythen::acquisitionTask()
             eventStatus = epicsEventWait(this->startEventId_);
             // setStringParam(ADStatusMessage, "Acquiring data");
             // setIntegerParam(ADNumImagesCounter, 0);
-	          // getIntegerParam(ADAcquire, &acquire);
-	          
-	              
-	          //printf("Read Mode: %d\tnModules: %d\t chanperline: %d\n", readmode_,this->nmodules,chanperline_);
+              // getIntegerParam(ADAcquire, &acquire);
+              
+                  
+              //printf("Read Mode: %d\tnModules: %d\t chanperline: %d\n", readmode_,this->nmodules,chanperline_);
             if (readmode_==0)       //Raw Mode
-	            nread_expect = sizeof(epicsInt32)*this->nmodules*(1280/chanperline_);
-	          else
-	            nread_expect = sizeof(epicsInt32)*this->nmodules*(1280);
-	            
-	          dataOK = 1;
-	          retry = 2;
-	          
-	          eventStatus = getStatus();
-	          setIntegerParam(ADStatus, eventStatus);
-	          
-	          if (eventStatus!=ADStatusError)
-	          {
-	            	            
-	            getDoubleParam(ADAcquireTime,&acquireTime);
+                nread_expect = sizeof(epicsInt32)*this->nmodules*(1280/chanperline_);
+            else
+                nread_expect = sizeof(epicsInt32)*this->nmodules*(1280);
+                
+            dataOK = 1;
+
+            eventStatus = getStatus();
+            setIntegerParam(ADStatus, eventStatus);
+
+            if (eventStatus!=ADStatusError) {
+
+              getDoubleParam(ADAcquireTime,&acquireTime);
               // printf("Acquisition start - expect %d\n",nread_expect);
               // Work on the cases of what are you getting from getstatus
               do {
@@ -891,63 +889,56 @@ void mythen::acquisitionTask()
                   strcpy(outString_, "-readoutraw");
                 else
                   strcpy(outString_, "-readout");
-                
-              	status = pasynOctetSyncIO->writeRead(pasynUserMeter_, outString_, strlen(outString_), (char *)detArray,
-              						    nread_expect, M1K_TIMEOUT+acquireTime, &nwrite, &nread, &eomReason);  //Timeout is M1K_TIMEOUT + AcquireTime
+
+                status = pasynOctetSyncIO->writeRead(pasynUserMeter_, outString_, strlen(outString_), (char *)detArray,
+                                        nread_expect, M1K_TIMEOUT+acquireTime, &nwrite, &nread, &eomReason);  //Timeout is M1K_TIMEOUT + AcquireTime
 
                 //printf("nread_expected = %d\tnread = %d\n", nread_expect,nread);
-                
-                if(nread == nread_expect)
-	              {
-	                this->lock();
-	                dataOK = dataCallback(detArray);
-	                this->unlock();
-	                if (!dataOK)
-	                  {
-	                    eventStatus = getStatus();
-	                    setIntegerParam(ADStatus, eventStatus);
-	                  }
-	                
-	              }
-                else
-                {
-	                eventStatus = getStatus();
-	                setIntegerParam(ADStatus, eventStatus);
+
+                if(nread == nread_expect) {
+                    this->lock();
+                    dataOK = dataCallback(detArray);
+                    this->unlock();
+                    if (!dataOK) {
+                        eventStatus = getStatus();
+                        setIntegerParam(ADStatus, eventStatus);
+                    }
+
+                }
+                else {
+                    eventStatus = getStatus();
+                    setIntegerParam(ADStatus, eventStatus);
                   //printf("Data not size expected ADStatus: %d\n",eventStatus);
                 }
-                if(status != asynSuccess)
-	              {
-	                asynPrint(pasynUserSelf, ASYN_TRACE_ERROR,
-		                  "%s:%s: error using readout command status=%d, nRead=%d, eomReason=%d\n",
-		                  driverName, functionName, status, (int)nread, eomReason);
-	              }
+                if(status != asynSuccess) {
+                    asynPrint(pasynUserSelf, ASYN_TRACE_ERROR,
+                          "%s:%s: error using readout command status=%d, nRead=%d, eomReason=%d\n",
+                          driverName, functionName, status, (int)nread, eomReason);
+                }
               } 
-            while (status == asynSuccess && (eventStatus==ADStatusAcquire||eventStatus==ADStatusReadout) && acquiring_);
+              while (status == asynSuccess && (eventStatus==ADStatusAcquire||eventStatus==ADStatusReadout) && acquiring_);
              
            }
            this->lock();
-	        
+            
         }
-        if (eventStatus!=ADStatusError )
-        {
+        if (eventStatus!=ADStatusError ) {
           printf("Acquisition finish\n");
           getIntegerParam(ADImageMode, &imageMode);
-          if (imageMode == ADImageSingle || imageMode == ADImageMultiple)
-          {
-	          printf("ADAcquire Callback\n");
-	          acquiring_ = 0;
+          if (imageMode == ADImageSingle || imageMode == ADImageMultiple) {
+            printf("ADAcquire Callback\n");
+            acquiring_ = 0;
             setIntegerParam(ADAcquire,  0); 
             callParamCallbacks(); 
           }
         }
-        else
-        {
+        else {
           //Abort read 
           asynPrint(pasynUserSelf, ASYN_TRACE_ERROR,
                 "%s:%s: error timed out waiting for data\n",
                 driverName, functionName);
           acquiring_ = 0;
-	        setAcquire(0);
+            setAcquire(0);
           setIntegerParam(ADAcquire,  0); 
           callParamCallbacks(); 
         }
@@ -1039,34 +1030,29 @@ void mythen::decodeRawReadout(int nmods, int nbits, int *data, int *result)
   // default for 24 bits
   int chanperline = 1; // default for 24 bits
   int mask=0xffffff; // default for 24 bits
-  if (nbits == 16)
-    {
+  if (nbits == 16) {
       chanperline = 2;
       mask=0xffff;
-    }
-  if (nbits == 8)
-    {
+  }
+  if (nbits == 8) {
       chanperline = 4;
       mask=0xff;
-    }
-  if (nbits == 4)
-    {
+  }
+  if (nbits == 4) {
       chanperline = 8;
       mask=0xf;
-    }
+  }
 
   int size = 1280/chanperline*nmods;
   u_int32_t tmpArray[size]; // the data has to interpreted
   memcpy(tmpArray, data, size*sizeof(int)); // unsigned int32
-  for (int j = 0; j < chanperline; j++)
-    {
+  for (int j = 0; j < chanperline; j++) {
       int shift = nbits*j;
       int shiftedMask = mask<<shift;
-      for (int i = 0; i < size; i++)
-	{
-	  result[i*chanperline+j]=((tmpArray[i]&shiftedMask)>>shift)&mask;
-	}
+      for (int i = 0; i < size; i++) {
+        result[i*chanperline+j]=((tmpArray[i]&shiftedMask)>>shift)&mask;
     }
+  }
 }
 
 
@@ -1134,43 +1120,41 @@ asynStatus mythen::writeInt32(asynUser *pasynUser, epicsInt32 value)
      * status at the end, but that's OK */
     status |= setIntegerParam(function, value);
 
-    if (function == ADAcquire)
-    {
+    if (function == ADAcquire) {
       getIntegerParam(SDReadMode, &readmode_);
       status |= setAcquire(value);
     }
-    else 
-      {
-	if (function == SDSetting) {
-	  status |= loadSettings(value);
-	} else if (function == SDUseFlatField) {
-	  status |= setFCorrection(value);
-	} else if (function == SDUseCountRate) {
-	  status |= setRCorrection(value);
-	} else if (function == SDUseBadChanIntrpl) {
-	  status |= setBadChanIntrpl(value);
-	} else if (function == SDBitDepth) {
-	  status |= setBitDepth(value);
-	} else if (function == SDNumGates) {
-	  status = setNumGates(value);
-	} else if (function == SDUseGates) {
-	  status = setUseGates(value);
-	} else if (function == SDNumFrames) {
-	  status |= setFrames(value);
-	} else if (function == SDTrigger) {
-	  status |= setTrigger(value);
-	} else if (function == SDReset) {
-	  status |= setReset();
-	} else if (function == ADImageMode) {
-	
-	  //getIntegerParam(SDNumFrames, &frames_);
-	  status |= setFrames(frames_);
-	} else {
-	  /* If this is not a parameter we have handled call the base class */
-	  if (function < FIRST_SD_PARAM) status = ADDriver::writeInt32(pasynUser, value);
-	}
-	status |= getSettings();
+    else {
+      if (function == SDSetting) {
+        status |= loadSettings(value);
+      } else if (function == SDUseFlatField) {
+        status |= setFCorrection(value);
+      } else if (function == SDUseCountRate) {
+        status |= setRCorrection(value);
+      } else if (function == SDUseBadChanIntrpl) {
+        status |= setBadChanIntrpl(value);
+      } else if (function == SDBitDepth) {
+        status |= setBitDepth(value);
+      } else if (function == SDNumGates) {
+        status = setNumGates(value);
+      } else if (function == SDUseGates) {
+        status = setUseGates(value);
+      } else if (function == SDNumFrames) {
+        status |= setFrames(value);
+      } else if (function == SDTrigger) {
+        status |= setTrigger(value);
+      } else if (function == SDReset) {
+        status |= setReset();
+      } else if (function == ADImageMode) {
+
+        //getIntegerParam(SDNumFrames, &frames_);
+        status |= setFrames(frames_);
+      } else {
+        /* If this is not a parameter we have handled call the base class */
+        if (function < FIRST_SD_PARAM) status = ADDriver::writeInt32(pasynUser, value);
       }
+      status |= getSettings();
+    }
  
     /* Update any changed parameters */
     status |= callParamCallbacks();
@@ -1271,7 +1255,7 @@ extern "C" int mythenConfig(const char *portName, const char *IPPortName,
                                     int priority, int stackSize)
 {
     new mythen(portName, IPPortName,
-		 maxBuffers, maxMemory, priority, stackSize);
+         maxBuffers, maxMemory, priority, stackSize);
     return(asynSuccess);
 }
 
@@ -1295,7 +1279,7 @@ mythen::mythen(const char *portName, const char *IPPortName,
                0, 0,             /* No interfaces beyond those set in ADDriver.cpp */
                ASYN_CANBLOCK | ASYN_MULTIDEVICE, 1, /* ASYN_CANBLOCK=1, ASYN_MULTIDEVICE=1, autoConnect=1 */
                priority, stackSize)
-		 // , pDetector(NULL)
+         // , pDetector(NULL)
 
 {
     int status = asynSuccess;
@@ -1303,6 +1287,8 @@ mythen::mythen(const char *portName, const char *IPPortName,
     const char *functionName = "mythen";
 
     IPPortName_ = epicsStrDup(IPPortName);
+    
+    isBigEndian_ = EPICS_BYTE_ORDER == EPICS_ENDIAN_BIG;
 
     /* Create the epicsEvents for signaling to the mythen task when acquisition starts and stops */
     this->startEventId_ = epicsEventCreate(epicsEventEmpty);
@@ -1377,11 +1363,11 @@ mythen::mythen(const char *portName, const char *IPPortName,
     //get nmodules and check for errors
     strcpy(outString_, "-get nmodules");
     status |= writeReadMeter();
-    aux=*((int*)this->inString_);
+    aux = stringToInt32(this->inString_);
     if (aux < 0) {
       asynPrint(pasynUserSelf, ASYN_TRACE_ERROR,
-		"%s:%s: error, outString=%s, inString=%s\n",
-		driverName, functionName, outString_, inString_);
+        "%s:%s: error, outString=%s, inString=%s\n",
+        driverName, functionName, outString_, inString_);
       return;
     }
     this->nmodules=aux;


### PR DESCRIPTION
I made the following changes:
- Made the driver compatible with ADCore R2-4 which is about to be released.  commonDriverMakefile and commonPlugins.cmd have been moved to ADExample.
- Fixed many compiler warnings in mythen.cpp
- mythen.cpp would not have worked on big-endian machines (e.g. Motorola MVME CPUs) because a char\* was being cast to an int\* for float*.  For a little-endian machine this works because the Mythen is little-endian, but on a big-endian machine the bytes will be in the wrong order.
- Removed tabs from mythen.cpp.  We are trying to follow the Google style guide which says no tabs.
- Reformatted mythen.cpp in many places to use consistent indentation to make the code more readable.  There is still a mix of 2 and 4 character indentation.  One should try to use one or the other consistently in a file.  
- To see the more substantive changes I made do "git diff -w -b mythen.cpp".  That will ignore changes in whitespace and blank lines.
