### PR TITLE
Updates/fixes to the driver, works at NSLS2

### DIFF
--- a/iocs/mythenIOC/iocBoot/iocMythen/auto_settings.req
+++ b/iocs/mythenIOC/iocBoot/iocMythen/auto_settings.req
@@ -1,8 +1,4 @@
-file "ADBase_settings.req",         P=$(P),  R=cam1:
-$(P)cam1:AcquireTime.PREC
-file "NDFile_settings.req",         P=$(P),  R=cam1:
 file "mythen_settings.req",       P=$(P),  R=cam1:
-file "NDPluginBase_settings.req",   P=$(P),  R=image1:
-file "NDStdArrays_settings.req",    P=$(P),  R=image1:
-file "commonPlugin_settings.req",   P=$(P)
-
+file "mythen_settings.req",       P=$(P),  R=cam1:
+file "NDStdArrays_settings.req",  P=$(P),  R=image1:
+file "commonPlugin_settings.req", P=$(P)

--- a/iocs/mythenIOC/iocBoot/iocMythen/st.cmd
+++ b/iocs/mythenIOC/iocBoot/iocMythen/st.cmd
@@ -53,7 +53,7 @@ dbLoadRecords("$(ADCORE)/db/NDStdArrays.template", "P=$(PREFIX),R=image1:,PORT=I
 # Load asynRecord records on Mythen communication
 dbLoadRecords("$(ASYN)/db/asynRecord.db", "P=$(PREFIX),R=asyn_1,PORT=IP_M1K,ADDR=0,OMAX=256,IMAX=256")
 
-set_requestfile_path("$(TOP)/mythenApp/Db")
+set_requestfile_path("$(ADMYTHEN)/mythenApp/Db")
 
 iocInit()
 


### PR DESCRIPTION
I have finally got hands on another Mythen unit and tried #4. It compiles but did not work for me. Many standard PVs were red, and I could not acquire. 

The changes in this PR makes all standard PVs accessible, and one can acquire an image (spectra actually).
![image](https://user-images.githubusercontent.com/21367956/233473236-a5da7064-53f6-4ab2-9a94-1ee4eddf112a.png)

The changes needs clean up at least from my personal comments, if considered for merging, and quite possible something else. 

I would need to add one more feature for this beamline. They have a 24 channel unit which is programmed (by Dectris) to use 5 modules. They have only 3. In order for everything to work, one needs to set the actual number of connected modules . Currently I use Dectris web client for this.  

The changes in this PR were done some time ago for another beamline with 1 Channel Mythen. 

Also, while I am around this unit, I can work on the documentation. Not sure how start though. 