### PR TITLE
Adding test pattern readout mode

### DIFF
--- a/iocs/mythenIOC/iocBoot/iocMythen/auto_settings.req
+++ b/iocs/mythenIOC/iocBoot/iocMythen/auto_settings.req
@@ -5,4 +5,3 @@ file "mythen_settings.req",       P=$(P),  R=cam1:
 file "NDPluginBase_settings.req",   P=$(P),  R=image1:
 file "NDStdArrays_settings.req",    P=$(P),  R=image1:
 file "commonPlugin_settings.req",   P=$(P)
-

--- a/iocs/mythenIOC/iocBoot/iocMythen/st.cmd
+++ b/iocs/mythenIOC/iocBoot/iocMythen/st.cmd
@@ -11,9 +11,9 @@ mythenApp_registerRecordDeviceDriver(pdbbase)
 
 #drvAsynIPPortConfigure("portName","hostInfo",priority,noAutoConnect,
 #                        noProcessEos)
-drvAsynIPPortConfigure("IP_M1K", "192.168.0.90:1030 UDP", 0, 0, 1)
+#drvAsynIPPortConfigure("IP_M1K", "192.168.0.90:1030 UDP", 0, 0, 1)
 #drvAsynIPPortConfigure("IP_M1K", "192.168.0.90:1031", 0, 0, 1)
-#drvAsynIPPortConfigure("IP_M1K", "164.54.109.66:1031", 0, 0, 0)
+drvAsynIPPortConfigure("IP_M1K", "164.54.109.66:1031", 0, 0, 0)
 
 #asynOctetSetInputEos("IP_M1K",0,"\r\n")
 asynOctetSetOutputEos("IP_M1K",0,"\r")
@@ -58,4 +58,4 @@ set_requestfile_path("$(TOP)/mythenApp/Db")
 iocInit()
 
 # save things every thirty seconds
-create_monitor_set("auto_settings.req", 30,"P=$(PREFIX),D=cam1:")
+create_monitor_set("auto_settings.req", 30,"P=$(PREFIX)")

--- a/mythenApp/Db/mythen.template
+++ b/mythenApp/Db/mythen.template
@@ -362,7 +362,9 @@ record (mbbo, "$(P)$(R)ReadMode")
     field (ZRVL, "0")
     field (ONST, "Corrected")
     field (ONVL, "1")
-    field (VAL,  "0")
+    field (TWST, "Test Pattern")
+    field (TWVL, "2")
+    field (VAL,  "1")
     field (PINI, "YES")
 }
 
@@ -375,6 +377,8 @@ record (mbbi, "$(P)$(R)ReadMode_RBV")
     field (ZRVL, "0")
     field (ONST, "Corrected")
     field (ONVL, "1")
+    field (TWST, "Test Pattern")
+    field (TWVL, "2")
     field (SCAN, "I/O Intr")
 }
 

--- a/mythenApp/src/mythen.cpp
+++ b/mythenApp/src/mythen.cpp
@@ -891,7 +891,7 @@ void mythen::acquisitionTask()
                 else if (readmode_==1)
                   strcpy(outString_, "-readout");
                 else
-                  strcpy(outstring_, "-testpattern");
+                  strcpy(outString_, "-testpattern");
 
                 status = pasynOctetSyncIO->writeRead(pasynUserMeter_, outString_, strlen(outString_), (char *)detArray_,
                                         nread_expect, M1K_TIMEOUT+acquireTime, &nwrite, &nread, &eomReason);  //Timeout is M1K_TIMEOUT + AcquireTime

--- a/mythenApp/src/mythen.cpp
+++ b/mythenApp/src/mythen.cpp
@@ -888,14 +888,16 @@ void mythen::acquisitionTask()
                 nread=0;
                 if (readmode_==0)
                   strcpy(outString_, "-readoutraw");
-                else
+                else if (readmode_==1)
                   strcpy(outString_, "-readout");
+                else
+                  strcpy(outstring_, "-testpattern");
 
                 status = pasynOctetSyncIO->writeRead(pasynUserMeter_, outString_, strlen(outString_), (char *)detArray_,
                                         nread_expect, M1K_TIMEOUT+acquireTime, &nwrite, &nread, &eomReason);  //Timeout is M1K_TIMEOUT + AcquireTime
 
-                //printf("nread_expected=%d, nread=%d, status=%d, timeout=%f, eomReason=%d\n",
-                //        (int)nread_expect, (int)nread, status, M1K_TIMEOUT+acquireTime, eomReason);
+                asynPrint(pasynUserSelf, ASYN_TRACE_FLOW, "%s:%s, nread_expected=%d, nread=%d, status=%d, timeout=%f, eomReason=%d\n",
+                       driverName, functionName, (int)nread_expect, (int)nread, status, M1K_TIMEOUT+acquireTime, eomReason);
 
                 if(nread == nread_expect) {
                     this->lock();

--- a/mythenApp/src/mythen.cpp
+++ b/mythenApp/src/mythen.cpp
@@ -896,7 +896,7 @@ void mythen::acquisitionTask()
                 status = pasynOctetSyncIO->writeRead(pasynUserMeter_, outString_, strlen(outString_), (char *)detArray_,
                                         nread_expect, M1K_TIMEOUT+acquireTime, &nwrite, &nread, &eomReason);  //Timeout is M1K_TIMEOUT + AcquireTime
 
-                asynPrint(pasynUserSelf, ASYN_TRACE_FLOW, "%s:%s, nread_expected=%d, nread=%d, status=%d, timeout=%f, eomReason=%d\n",
+                asynPrint(pasynUserSelf, ASYN_TRACE_FLOW, "%s:%s: nread_expected=%d, nread=%d, status=%d, timeout=%f, eomReason=%d\n",
                        driverName, functionName, (int)nread_expect, (int)nread, status, M1K_TIMEOUT+acquireTime, eomReason);
 
                 if(nread == nread_expect) {

--- a/mythenApp/src/mythen.cpp
+++ b/mythenApp/src/mythen.cpp
@@ -903,11 +903,8 @@ void mythen::acquisitionTask()
                     this->lock();
                     dataOK = dataCallback(detArray_);
                     this->unlock();
-                    if (!dataOK) {
-                        eventStatus = getStatus();
-                        setIntegerParam(ADStatus, eventStatus);
-                    }
-
+                    eventStatus = getStatus();
+                    setIntegerParam(ADStatus, eventStatus);
                 }
                 else {
                     eventStatus = getStatus();


### PR DESCRIPTION
This mode was useful for debugging why I wasn't seeing valid readouts. This PR also changes the default mode to `Corrected` - I was not able to get the raw readout mode working as expected.